### PR TITLE
Intel + Surrender + Check (UPDATE)

### DIFF
--- a/Main2.cpp
+++ b/Main2.cpp
@@ -43,7 +43,7 @@ int main()
     //initial conditions;
 
     int population, air_military, infantry_military, commerce, military_factory, land, food,
-            happiness_factor, ospy, cspy, undercover_spy, ucs_north, ucs_south, ucs_east, ucs_west, city;
+            happiness_factor, ospy, cspy, undercover_spy, ucs_north, ucs_south, ucs_east, ucs_west, city, check;
     population = 100000;
     air_military = 100;
     infantry_military = 1000;
@@ -60,6 +60,8 @@ int main()
     ucs_east = 0;
     ucs_west = 0;
     city = 1;
+    check = 0;
+
 
     int year = 1921;
     int food_stores=food;
@@ -242,12 +244,36 @@ int main()
                 if(next_year_option==1)
         {
             year++;//Increments year (Added here because if we go to war room it adds an extra year on top)
+            int skirmish_choice;
+            cout<<"Who do you want to go to skirmish against?\n";
+            cout<<"1) "<<north_name<<endl;
+            cout<<"2) "<<south_name<<endl;
+            cout<<"3) "<<east_name<<endl;
+            cout<<"4) "<<west_name<<endl;
+            sentinelFunction(1,4,skirmish_choice);
             number_of_wars++;
-            bool war_win = win_war_Skirmish(population, land, infantry_military, commerce, city/*, north_name, south_name, east_name, west_name */);
+            bool war_win = false;
+            if (skirmish_choice ==1)
+            {
+                win_war_Skirmish(population, land, infantry_military, commerce, city, north_name, ucs_north, north_air_military, north_infantry_military, ospy, check);
+            }
+            else if (skirmish_choice ==2)
+            {
+                win_war_Skirmish(population, land, infantry_military, commerce, city, south_name, ucs_south, south_air_military, south_infantry_military, ospy, check);
+            }
+            else if (skirmish_choice ==3)
+            {
+                win_war_Skirmish(population, land, infantry_military, commerce, city, east_name, ucs_east, east_air_military, east_infantry_military, ospy, check);
+            }
+            else if (skirmish_choice ==4)
+            {
+                win_war_Skirmish(population, land, infantry_military, commerce, city, west_name, ucs_west, west_air_military, west_infantry_military, ospy, check);
+            }
             if(war_win)
             {
                 cout<<"You have won the war!\n\n";
                 number_of_wars_won++;
+
                 // Happiness Effects
                 if (happiness_factor < 100)
                     happiness_factor = happiness_factor +10;
@@ -256,8 +282,17 @@ int main()
             }
             else
             {
-                cout<<"You have lost the war!\n\n";
-                happiness_factor = happiness_factor -10;
+                if(check == 0)
+                {cout<<"You have lost the war!\n\n";
+
+                happiness_factor = happiness_factor -10;}
+                else
+                {
+                    check--;
+                    number_of_wars--;
+                    year--;
+                }
+
 
             }
         }
@@ -352,8 +387,31 @@ int main()
         if(next_year_option==1)
         {
             year++;//Increments year (Added here because if we go to war room it adds an extra year on top)
+            int skirmish_choice;
+            cout<<"Who do you want to go to skirmish against?\n";
+            cout<<"1) "<<north_name<<endl;
+            cout<<"2) "<<south_name<<endl;
+            cout<<"3) "<<east_name<<endl;
+            cout<<"4) "<<west_name<<endl;
+            sentinelFunction(1,4,skirmish_choice);
             number_of_wars++;
-            bool war_win = win_war_Skirmish(population, land, infantry_military, commerce, city/*, north_name, south_name, east_name, west_name*/);
+            bool war_win = false;
+            if (skirmish_choice ==1)
+            {
+                win_war_Skirmish(population, land, infantry_military, commerce, city, north_name, ucs_north, north_air_military, north_infantry_military, ospy, check);
+            }
+            else if (skirmish_choice ==2)
+            {
+                win_war_Skirmish(population, land, infantry_military, commerce, city, south_name, ucs_south, south_air_military, south_infantry_military, ospy, check);
+            }
+            else if (skirmish_choice ==3)
+            {
+                win_war_Skirmish(population, land, infantry_military, commerce, city, east_name, ucs_east, east_air_military, east_infantry_military, ospy, check);
+            }
+            else if (skirmish_choice ==4)
+            {
+                win_war_Skirmish(population, land, infantry_military, commerce, city, west_name, ucs_west, west_air_military, west_infantry_military, ospy, check);
+            }
             if(war_win)
             {
                 cout<<"You have won the war!\n\n";
@@ -367,9 +425,20 @@ int main()
             }
             else
             {
-                cout<<"You have lost the war!\n\n";
+                if ( check ==0)
+                {
+                    cout<<"You have lost the war!\n\n";
 
                 happiness_factor = happiness_factor -10;
+                }
+                else
+                {
+                    check--;
+                    number_of_wars--;
+                    year--;
+                }
+
+
             }
         }
         else if(next_year_option==2)
@@ -383,6 +452,7 @@ int main()
          else if (next_year_option ==4)
         {
             year++;
+            cout<<"\nConstructing city. Est wait time: 5 years\n";
             building_city = true;
             commerce = commerce - 15000; // City building takes 15000 units of commerces
             remaining_time_city_construction = 5;
@@ -444,7 +514,7 @@ int main()
         else if (next_year_option==7)
         {
             year++;
-            player_attack_spy(north_name, south_name, east_name, west_name,  ospy, undercover_spy);
+            player_attack_spy(north_name, south_name, east_name, west_name,  ospy, undercover_spy,ucs_north,ucs_south,ucs_east,ucs_west);
         }
          else if(next_year_option==8)
         {
@@ -817,5 +887,5 @@ int main()
 
     }
 
-
 }
+

--- a/sim_countryfuncs.cpp
+++ b/sim_countryfuncs.cpp
@@ -47,9 +47,8 @@ int d4_Random_Roll() // For enemy country selection
 }
 
 
-bool win_war_Skirmish(int& population, int& land, int& military, int& money, int& city/*, string& n_name,
-                      string& s_name,string& e_name,string& w_name, int&ucs_north, int& ucs_south,
-                        int& ucs_east, int& ucs_west */)
+bool win_war_Skirmish(int& population, int& land, int& military, int& money, int& city,
+                      string& enemy, int& ucs, int& e_af, int& e_inf, int&ospy, int& check)
 {
     int chance = d100_Random_Roll();
     double win_pop = 0.90, win_land = 1.15, win_mil = 0.85;
@@ -57,44 +56,57 @@ bool win_war_Skirmish(int& population, int& land, int& military, int& money, int
     //If lose= -25% pop, -10% land, -30%military
     //If win= -10%pop, +15%land, -15% military
     //weight = military based
-    /*cout << "Who do you wish to attack? \n";
-    cout << "1) " << n_name << endl;
-    cout << "2) " << s_name << endl;
-    cout << "3) " << e_name << endl;
-    cout << "4) " << w_name << endl;
     int choice;
-    sentinelFunction(1,4,choice);
-
-    if (choice == 1)
+    if (ucs !=0)
     {
-        if(ucs_north == 0)
+        cout << "Intel on " << enemy << " is as follows: \n";
+        cout << "Air Force count is between " << 0.9* e_af << " and " << 1.1 * e_af << endl;
+        cout << "Infantry count is between " << 0.9* e_inf << " and " << 1.1 * e_inf << endl;
+        ucs--;
+        ospy++;
+    }
+    else
+    {
+        cout << "There is no intel on " << enemy << endl;
+    }
+
+    cout << "Do you still wish to attack?" << endl;
+    cout << "Enter 1 for Yes. 0 for No" << endl;
+    sentinelFunction(0,1,choice);
+    if (choice ==1)
+    {
+           if(chance>50)
         {
-            cout << "No intel"
+            population  = population* win_pop;
+            land        = land      * win_land;
+            military    = military  * win_mil;
+            money = money *0.95; // Commerce loss
+            city = city + 1;;
+            return true;
         }
-    }
-*/
+        else if(chance<51)
+        {
+            population  =population * loss_pop;
+            land        =land       * loss_land;
+            military    =military   * loss_mil;
+            money = money * 0.85; // Commerce Loss
+            city = city- 1;;
+
+            return false;
+        }
+        }
+    else
+        {
+            check++;;
+        }
 
 
 
-    if(chance>50)
-    {
-        population  = population* win_pop;
-        land        = land      * win_land;
-        military    = military  * win_mil;
-        money = money *0.95; // Commerce loss
-        city = city + 1;;
-        return true;
-    }
-    else if(chance<51)
-    {
-        population  =population * loss_pop;
-        land        =land       * loss_land;
-        military    =military   * loss_mil;
-        money = money * 0.85; // Commerce Loss
-        city = city- 1;;
 
-        return false;
-    }
+
+
+
+
 }
 
 /**Definite(?) version of the skirmish function which also takes into account the AI's stats
@@ -289,10 +301,11 @@ bool war_Room (int &air_player, int &infantry_player,  int &land, int& populatio
         cout << "1: Air force \n" ;
         cout << "2: Infantry \n" ;
         cout<< "3: Both \n" ;
-        cout << "4: Send White Flag \n" << endl;
+        cout << "4: Surrender \n";
+        cout << "5: Send White Flag \n" << endl;
         int choice;
 
-        sentinelFunction(1, 4, choice);
+        sentinelFunction(1, 5, choice);
         // Game interaction
         {
 
@@ -537,19 +550,32 @@ bool war_Room (int &air_player, int &infantry_player,  int &land, int& populatio
                             cout << "City Count: " << city << endl;
                         }}}
             }
-            else if (choice == 4)
+            else if (choice ==4)
             {
-                cout << "You send a peace treaty to the enemy" << endl;
+                    cout << "If you surrender you will lose 50% of your land and cities!" << endl;
+                    cout << "Do you wish to continue? \n";
+                    cout << "Press 1 for Yes. 0 for no \n";
+                    int x;
+                    sentinelFunction(0,1,x);
+                    if( x ==1)
+                    {
+                        cout << "The enemy has accepted your surrender" << endl;
+                        cout << "You will now lose 50% of your land and cities but keep your airforce and infantry intact" << endl;
+                        land = land * 0.5;
+                        city = city * 0.5;
+                        cout << "You now have: " << land << " land" << endl;
+                        cout << "City Count: " << city << endl;
+                    }
+
+            }
+            else if (choice == 5)
+            {
+                cout << "You send a white flag to the enemy" << endl;
                 int accept = d100_Random_Roll();
                 if ( accept  > f)
                 {
 
-                    cout << "The enemy has accepted your peace treaty" << endl;
-                    cout << "You will now lose 50% of your land and cities but keep your airforce and infantry intact" << endl;
-                    land = land * 0.5;
-                    city = city * 0.5;
-                    cout << "You now have: " << land << " land" << endl;
-                    cout << "City Count: " << city << endl;
+                    cout << "The enemy agrees to a ceasefire" << endl;
                     int year_passed = turns/10;
                     year = year + year_passed;
                     cout << "The war lasted " << year_passed << " year(s)!" << endl;
@@ -557,8 +583,9 @@ bool war_Room (int &air_player, int &infantry_player,  int &land, int& populatio
                 }
                 else
                 {
-                    cout << "The enemy reject your offer" << endl;
+                    cout << "The enemy rejects your ceasefire" << endl;
                 }
+
             }
             int enemy_surrender = d100_Random_Roll();
                 {
@@ -694,7 +721,7 @@ string toUpper(string &str) // Needs to be implemented
     return d;
 }
 
-int spy(int &ospy, int& cspy)
+int spy (int &ospy, int& cspy)
 {
     cout << "Do you want to train \n"
             "1 : Spy (Will infiltrate other countries) \n"
@@ -733,7 +760,7 @@ void enemyspyattack(int &s_chance, string& e_s_country, int& cspy, int& af, int&
 {
     float const afloss = 0.05, infloss = 0.1;
     int def_chance = d100_Random_Roll();
-    if (s_chance < 61) // 60% chance of spy attack
+    if (s_chance < 81) // 60% chance of spy attack
     {
         if (def_chance < 61 && cspy > 0 )
         {
@@ -770,8 +797,8 @@ void enemyspyattack(int &s_chance, string& e_s_country, int& cspy, int& af, int&
 }
 
 void player_attack_spy(string &n_name,string &s_name,  string &e_name,
-                        string &w_name,   int &ospy, int &undercoverspy /*, int&ucs_north, int& ucs_south,
-                        int& ucs_east, int& ucs_west*/)
+                        string &w_name,   int &ospy, int &undercoverspy , int&ucs_north, int& ucs_south,
+                        int& ucs_east, int& ucs_west)
 
 {
 
@@ -793,7 +820,7 @@ void player_attack_spy(string &n_name,string &s_name,  string &e_name,
             << " HQ! You will receive Intel on them before the next battle!" << endl;
             undercoverspy++;
             ospy--;
-            //ucs_north++;
+            ucs_north++;
 
 
         }
@@ -812,7 +839,7 @@ void player_attack_spy(string &n_name,string &s_name,  string &e_name,
             << " HQ! You will receive Intel on them before the next battle!" << endl;
             undercoverspy++;
             ospy--;
-            //ucs_south++;
+            ucs_south++;
         }
         else
         {
@@ -829,7 +856,7 @@ void player_attack_spy(string &n_name,string &s_name,  string &e_name,
             << " HQ! You will receive Intel on them before the next battle!" << endl;
             undercoverspy ++;
             ospy--;
-            //ucs_west++;
+            ucs_west++;
         }
         else
         {
@@ -846,7 +873,7 @@ void player_attack_spy(string &n_name,string &s_name,  string &e_name,
             << " HQ! You will receive Intel on them before the next battle!" << endl;
             undercoverspy++;
             ospy--;
-            //ucs_east++;
+            ucs_east++;
         }
         else
         {
@@ -894,7 +921,6 @@ void country_war_room (int &air_player, int &infantry_player,  int &land, int& p
     cout << "4) " << w_name << endl;
     int choice;
     sentinelFunction(1,4,choice);
-
     if (choice ==1)
     {
         bool war_win = war_Room(air_military,infantry_military,land,population,north_air_military,
@@ -905,7 +931,5 @@ void country_war_room (int &air_player, int &infantry_player,  int &land, int& p
         bool war_win = war_Room(air_military,infantry_military,land,population,north_air_military,
                                     south_infantry_military,player_name, year);
     }
-
-
 }
 */

--- a/sim_countryfuncs.h
+++ b/sim_countryfuncs.h
@@ -7,9 +7,8 @@
 
 bool player_wins_war(int& player_pop, int& player_land, int& player_infmili,int&player_airmili, int& neighbour_pop,
                      int& neighbour_infmili, int& neighbour_airmili);
-bool win_war_Skirmish(int& population, int& land, int& military, int& money, int& city /*, string& n_name,
-                      string& s_name,string& e_name,string& w_name, int&ucs_north, int& ucs_south,
-                        int& ucs_east, int& ucs_west*/); //stub. Must be replaced!!!
+bool win_war_Skirmish(int& population, int& land, int& military, int& money,
+                       int& city, int& ucs, int& e_af, int& e_inf, int& ospy, int& check); //stub. Must be replaced!!!
 int d100_Random_Roll();
 int d50_Random_Roll();
 int d10_Random_Roll();
@@ -25,8 +24,8 @@ void starvationFactor(int& population, int food_stores);
 int spy (int &ospy, int &cspy);
 void enemyspyattack(int &s_chance, std::string& e_s_country, int& cspy, int& af, int& inf );
 void player_attack_spy(std::string &n_name,std::string &s_name,  std::string &e_name,
-                        std::string &w_name,   int &ospy, int &undercoverspy /*, int&ucs_north, int& ucs_south,
-                        int& ucs_east, int& ucs_west */);
+                        std::string &w_name,   int &ospy, int &undercoverspy , int&ucs_north, int& ucs_south,
+                        int& ucs_east, int& ucs_west );
 bool happiness_loss (int &happy);
 void instructions (std::string& name);
 void cities(int &money);


### PR DESCRIPTION
- Intel options are in, giving a range of numbers
- Check installed to ensure that if you do not go to war, year does not increase and  number of wars does not increase either
- Yet to add spy poisoning options, will do in next break (Yes i do this in my breaks )
- Surrender and Ceasefire options in War Room are up
- I suggest we only allow other countries to hit us with an all out war once our stats hit a ceratin point, bilkul shuru mein thappa lag jaata hai and the enemy is much more powerful, game warh jaati hai.